### PR TITLE
fix(adjustXforWhitespace):  preserves the number of whitespaces and d…

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,13 +69,8 @@ const decorators = {
 // Some SVG Implementations drop whitespaces
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:space
 const adjustXforWhitespace = (text, x) => {
-	const leadingSpace = text.match(/(^ )/g)
-
-	if (leadingSpace && leadingSpace.length > 0) {
-		return x + leadingSpace.length
-	}
-
-	return x
+	const leadingSpace = text.match(/^\s*/g)
+  	return x + leadingSpace[0].length
 }
 
 const handler = (ansi, opts) => {


### PR DESCRIPTION
Hi, 

at first, great work! I found a small bug in your package. I tried to use it to create a code syntax highlighter. But your adjustXforWhitespace-function doesn't preserve whitespaces. Currently it only detects the existence of them and collapse it to one. I updated the regex and add the length of the detected whitespace at beginning of each text fragment to x.

Cheers
Stephan